### PR TITLE
Corrections liste d'appels

### DIFF
--- a/core/class/livebox.class.php
+++ b/core/class/livebox.class.php
@@ -34,6 +34,29 @@ class livebox extends eqLogic {
 		}
 	}
 
+	public function addFavorite($num,$name) {
+    log::add('livebox','info', __FUNCTION__ ." Num=$num Name=$name");
+		$responses = livebox_calls::searchByPhone($num);
+		if (!is_array($responses) || count($responses) ===0) {
+        // Il n'est pas dans la base, Ajout.
+			$caller = new livebox_calls;
+			$caller->setStartDate(date('Y-m-d H:i:s'));
+			$caller->setPhone($normalizedPhone);
+      $caller->setCallerName($name);
+      $caller->setFavorite(1);
+      $caller->setIsFetched(1);
+      $caller->save();
+    } else {
+        // Il est déjà dans la base
+			log::add('livebox','debug','caller already stored');
+			// On prend le premier retourné car priorité aux favoris et aux plus récents.
+			$caller = $responses[0];
+      $caller->setFavorite(1);
+      $caller->setIsFetched(1);
+      $caller->save();
+    }
+  }
+
 	public static function saveFavorites() {
 		$sql = 'UPDATE livebox_calls
 				SET `favorite`=0, `isFetched`=0
@@ -43,7 +66,7 @@ class livebox extends eqLogic {
 		} catch (Exception $e) {
 
 		}
-		$favoris = config::byKey('favorites','livebox', array());
+    $favoris = config::byKey('favorites','livebox', array());
 		foreach ( $favoris as $favori ) {
 			$callerName = trim($favori['callerName']);
 			$phone = trim($favori['phone']);
@@ -1171,7 +1194,6 @@ class livebox extends eqLogic {
 			$inCallsNumber = 0;
 			$missedCallsNumber = 0;
 			$setting = config::byKey('minincallduration','livebox', 5);
-			$usepagesjaunes = config::byKey('pagesjaunes','livebox', false);
 			$calls = array();
 
 			if ( isset($content["status"]) ) {
@@ -1203,7 +1225,7 @@ class livebox extends eqLogic {
 						$missed = 0;
 						$icon = '<i class="icon icon_green techno-phone2"</i>';
 					}
-					$calls[] = array("timestamp" => $ts, "num" => $Call_numero, "duree" => $Call_duree, "in" => $in, "missed" => $missed, "icon" => $icon);
+					$calls[] = array("timestamp" => $ts, "num" => $Call_numero, "duree" => $Call_duree, "in" => $in, "missed" => $missed, "icon" => $icon, "processed" => 0);
 
 				}
 				if(count($calls) > 1) {
@@ -1225,22 +1247,34 @@ class livebox extends eqLogic {
 
 			//	Tous les appels
 			if ($totalCallsNumber > 0) {
-				$callsTable = "$tabstyle<table border=1>";
-				if($usepagesjaunes == 1) {
-					$callsTable .=	"<tr><th>Nom</th><th>Numéro</th><th>Date</th><th>Durée</th><th></th></tr>";
-				} else {
-					$callsTable .=	"<tr><th>Numéro</th><th>Date</th><th>Durée</th><th></th></tr>";
-				}
-				foreach($calls as $key => $call) {
-					if($usepagesjaunes == 1) {
-						$callerName = trim($this->getCallerName($call["num"]));
-						log::add('livebox','debug','Caller name returned by getCallerName $'.$callerName.'$');
-						$callsTable .= "<tr><td>" . $callerName ."</td><td>".$this->fmt_numtel($call["num"])."</td><td>".$this->fmt_date($call["timestamp"])."</td><td>".$this->fmt_duree($call["duree"])."</td><td>".$call["icon"]."</td></tr>";
-					} else {
-					$callsTable .= "<tr><td>".$this->fmt_numtel($call["num"])."</td><td>".$this->fmt_date($call["timestamp"])."</td><td>".$this->fmt_duree($call["duree"])."</td><td>".$call["icon"]."</td></tr>";
-				}
-				}
-				$callsTable .= "</table>";
+        $groupCallsByPhone = config::byKey('groupCallsByPhone',__CLASS__, 0);
+        $callsTable = "$tabstyle<table border=1>";
+        $callsTable .=	"<tr><th>Nom</th><th>Numéro</th><th>Date</th><th>Durée</th><th></th></tr>";
+        $favorite=0;
+        foreach($calls as &$call) {
+          if($call["processed"] == 0) {
+            $callerName = trim($this->getCallerName($call["num"],$favorite));
+            // log::add(__CLASS__,'info','callerName '.$callerName);
+            log::add('livebox','debug','Caller name returned by getCallerName $'.$callerName.'$');
+          $callsTable .= "<tr>";
+          if($favorite == 1 ) // Pas de lien sur les favoris
+            $callsTable .= "<td>$callerName</td>";
+          else
+            $callsTable .= "<td><a class='btn-sm bt_plus' title='Ajouter $callerName " .$call["num"] ." en favori' target=_blank href=\"" .network::getNetworkAccess('internal', 'proto:ip') ."/plugins/livebox/desktop/php/addFavorite.php?num=".$call["num"]."&name=$callerName\"><i class='far fa-heart'></i></a> $callerName</td>";
+          $callsTable .= "<td>".$this->fmt_numtel($call["num"])."</td><td>".$this->fmt_date($call["timestamp"])."</td><td>".$this->fmt_duree($call["duree"])."</td><td>".$call["icon"]."</td></tr>";
+            $call["processed"] = 1;
+            if($groupCallsByPhone == 1) { // regroupement des appels par numero
+              foreach($calls as &$call2) {
+                if($call2["processed"] == 0 && $call["num"] == $call2["num"]) {
+                  $callsTable .= "<tr><td></td><td></td>";
+                  $callsTable .= "<td>".$this->fmt_date($call2["timestamp"])."</td><td>".$this->fmt_duree($call2["duree"])."</td><td>".$call2["icon"]."</td></tr>";
+                  $call2["processed"] = 1;
+                }
+              }
+            }
+          }
+        }
+        $callsTable .= "</table>";
 			}
 
 			//	Appels sortants
@@ -1378,11 +1412,13 @@ class livebox extends eqLogic {
 		return $num;
 	}
 
-	function getCallerName($num) {
+	function getCallerName($num,&$favorite=0) {
 		$normalizedPhone = $this->normalizePhone($num);
 		if (strlen($num) == 0) {
-			return 'Anonyme';
+      $favorite=1;
+      return 'Anonyme';
 		}
+    $usepagesjaunes = config::byKey('pagesjaunes','livebox', false);
 		$responses = livebox_calls::searchByPhone($normalizedPhone);
 		if (!is_array($responses) || count($responses) ===0) {
 			log::add('livebox','debug','caller not stored');
@@ -1391,35 +1427,45 @@ class livebox extends eqLogic {
 			$caller->setStartDate(date('Y-m-d H:i:s'));
 			$caller->setPhone($normalizedPhone);
 			$caller->setFavorite(0);
-			if ($this->_pagesJaunesRequests < self::MAX_PAGESJAUNES && strlen($num) == 10) {
-				log::add('livebox','debug','we fetch the name');
-				$this->_pagesJaunesRequests++;
-				$callerName = $this->getPjCallerName($normalizedPhone);
-				$caller->setCallerName($callerName);
-				$caller->setIsFetched(1);
-			} else {
-				log::add('livebox','debug','store it but not fetched');
-				$caller->setCallerName('');
-				$caller->setIsFetched(0);
-			}
+      $favorite = 0;
+      if($usepagesjaunes == 1) {
+        if ($this->_pagesJaunesRequests < self::MAX_PAGESJAUNES && strlen($num) == 10) {
+          log::add('livebox','debug','we fetch the name');
+          $this->_pagesJaunesRequests++;
+          $callerName = $this->getPjCallerName($normalizedPhone);
+          $caller->setCallerName($callerName);
+          $caller->setIsFetched(1);
+        } else {
+          log::add('livebox','debug','store it but not fetched');
+          $caller->setCallerName('');
+          $caller->setIsFetched(0);
+        }
+      }
+      else {
+        $caller->setCallerName('_');
+        $caller->setIsFetched(0);
+      }
 			$caller->save();
 		} else {
 			// Il est déjà dans la base
 			log::add('livebox','debug','caller already stored');
 			// On prend le premier retourné car priorité aux favoris et aux plus récents.
 			$caller = $responses[0];
+      $favorite = $caller->getFavorite();
 			if ($caller->getIsFetched() == 0 && $caller->getFavorite() == 0) {
 				log::add('livebox','debug','but it is not fetched and not favorite');
-				if ($this->_pagesJaunesRequests < self::MAX_PAGESJAUNES && strlen($num) == 10) {
-					log::add('livebox','debug','we fetch the name');
-					$this->_pagesJaunesRequests++;
-					$callerName = $this->getPjCallerName($normalizedPhone);
-					log::add('livebox','debug','response from pages jaunes '.$callerName);
-					$caller->setCallerName($callerName);
-					$caller->setIsFetched(1);
-					log::add('livebox','debug','and we save it');
-					$caller->save();
-				}
+        if($usepagesjaunes == 1) {
+          if ($this->_pagesJaunesRequests < self::MAX_PAGESJAUNES && strlen($num) == 10) {
+            log::add('livebox','debug','we fetch the name');
+            $this->_pagesJaunesRequests++;
+            $callerName = $this->getPjCallerName($normalizedPhone);
+            log::add('livebox','debug','response from pages jaunes '.$callerName);
+            $caller->setCallerName($callerName);
+            $caller->setIsFetched(1);
+            log::add('livebox','debug','and we save it');
+            $caller->save();
+          }
+        }
 			}
 		}
 		return $caller->getCallerName();

--- a/desktop/php/addFavorite.php
+++ b/desktop/php/addFavorite.php
@@ -1,0 +1,17 @@
+<?php
+$num="";
+$name="";
+if (isset( $_GET['num'])) $num=$_GET['num'];
+else if (isset( $_POST['num'])) $num=$_POST['num'];
+if (isset( $_GET['name'])) $name=$_GET['name'];
+else if (isset( $_POST['name'])) $name=$_POST['name'];
+
+if($num == "" || $name == "") {
+  echo "Empty args";
+  return;
+}
+include "../../core/class/livebox.class.php";
+
+$lb= new livebox();
+$lb->addFavorite($num,$name);
+

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -38,6 +38,12 @@ if (!isConnect()) {
 				<input class="configKey form-control" data-l1key="minincallduration" />
 			</div>
 		</div>
+		<div class="form-group">
+			<label class="col-sm-4 control-label">{{Regroupement par numéro de téléphone dans la liste des appels}}</label>
+			<div class="col-sm-2">
+				<input type="checkbox" class="configKey tooltips" data-l1key="groupCallsByPhone">
+			</div>
+		</div>
 	</fieldset>
 </form>
 <form class="form-horizontal">


### PR DESCRIPTION
Voici un PR pour les points suivants:

4 Regroupement des appels par numéro de tel dans la liste des appels. Ajout d'un paramètre dans la config du plugin.
6 Ebauche de la création de favoris à partir de la liste des appels. Pas pris le temps de chercher à faire un popup
10 La colonne Nom apparait toujours dans la liste des appels.

J'espère ne rien avoir oublié.