### PR TITLE
Roue crantée en boucle lors de l'accés à la config du plugin

### DIFF
--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -87,7 +87,7 @@ jeedom.config.load({
 	if(data === false){
 	  return;
 	}
-	data.sort((a, b) => a.callerName.localeCompare(b.callerName));
+	if (data.length > 1 ) data.sort((a, b) => a.callerName.localeCompare(b.callerName));
 	var tr='';
 	for(var i in data){
 	  tr += '<tr class="favorite">';


### PR DESCRIPTION
En v3, l'accés à la configuration du plugin n'est pas possible s'il n'existe aucun favori.
data.sort ne rend pas la main.