### PR TITLE
Variable non init dans addFavorite

### DIFF
--- a/core/class/livebox.class.php
+++ b/core/class/livebox.class.php
@@ -46,6 +46,7 @@ class livebox extends eqLogic {
 	}
 	public static function addFavorite($num,$name) {
 		$favoris = config::byKey('favorites','livebox',array());
+		$found = 0;
 		foreach ($favoris as $favori) {
 			if($favori['phone'] == $num){
 				$found = true;


### PR DESCRIPTION
Found n'est pas initialisée.
Peut etre le pb d'erreur 500 de lr3674 pour lequel il manque le log http.error
https://community.jeedom.com/t/roue-crantee-en-boucle-depuis-maj-plugin-du-06-01/13575/6