### PR TITLE
compatibility with PHP 8

### DIFF
--- a/core/class/livebox.class.php
+++ b/core/class/livebox.class.php
@@ -211,6 +211,7 @@ class livebox extends eqLogic {
 				log::add('livebox','debug','version 4');
 				$this->_version = "4";
 				curl_close($session);
+				unset($session);
 				$session = curl_init();
 
 				$paramInternet = '{"service":"sah.Device.Information","method":"createContext","parameters":{"applicationName":"so_sdkut","username":"'.$this->getConfiguration('username').'","password":"'.$this->getConfiguration('password').'"}}';
@@ -253,6 +254,7 @@ class livebox extends eqLogic {
 			}
 			$info = curl_getinfo($session);
 			curl_close($session);
+			unset($session);
 			$obj = json_decode($json);
 			if ( ! isset($obj->data->contextID) ) {
 				log::add('livebox','debug','unable to get contextID');
@@ -307,7 +309,8 @@ class livebox extends eqLogic {
 							"Accept-Encoding: gzip, deflate, br\r\n" .
 							"Accept-Language: fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4\r\n" .
 							"Cookie: ".$this->_cookies."; ; sah/contextId=".$this->_contextID,
-			 'content' => $paramInternet
+			 'content' => $paramInternet,
+			 'protocol_version' => '1.0'
 			)
 		);
 		return stream_context_create($httpInternet);

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -60,3 +60,7 @@ Le nom des appelants qui était Oups est maintenant configurable dans la page de
 # Version du 13/11/2020
 
 Ajout de styles spécifiques à ce plugin pour les listes d'appels. Auparavant les styles de Jeedom utilisés par d'autre plugin étaient redéfinis. Merci à jpty pour cette correction.
+
+# Version du 23/03/2024
+
+Compatibilité avec PHP 8


### PR DESCRIPTION
According to https://www.php.net/manual/en/function.curl-close.php The function curl_close has no effect. Prior to PHP 8.0.0, this function was used to close the resource. According to https://php.watch/versions/8.0/resource-CurlHandle we should  explicitly unset() the CurlHandle object.
Without unset, the cookies file is corrupted.

According to https://www.php.net/manual/en/function.stream-context-create.php and https://www.php.net/manual/en/context.http.php protocol_version Defaults to 1.1 as of PHP 8.0.0; prior to that version the default was 1.0.
Without forcing to version 1.0 we have to wait a lot of time.
